### PR TITLE
Fix yaml-cpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "external/rlutil"]
 	path = external/rlutil
 	url = https://github.com/tapio/rlutil
-[submodule "external/yaml-cpp"]
-	path = external/yaml-cpp
-	url = https://github.com/blair1618/yaml-cpp.git
-	branch = no-boost-rb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "external/rlutil"]
 	path = external/rlutil
 	url = https://github.com/tapio/rlutil
+[submodule "external/yaml-cpp"]
+	path = external/yaml-cpp
+	url = https://github.com/blair1618/yaml-cpp.git
+	branch = no-boost-rb


### PR DESCRIPTION
What you had was an invalid commit-pointer, which was pointing to a commit that didn't exist in the branch you were cloning, which was probably caused by `pull`ing `master`